### PR TITLE
Fix dependency version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.6</version>
+            <!-- The upstream librabry claims to be compatible with version >= 2.3.0. -->
+            <version>2.3.0</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
[Bootstrap tour](https://github.com/sorich87/bootstrap-tour#bootstrap-tour) claims to be compatible with any Bootstrap version >= 2.3.0. However, I have wrongly set the dependency to Bootstrap 3.3.6 in the previous version of the webjar. It's a problem because now the webjar is not compatible with older versions of Bootstrap meanwhile the upstream library is.

I suggest to merge this pull request and to release a webjar minor version.

Sorry for the inconvenience.

Thanks for your help,

Guillaume
